### PR TITLE
Implement vertical navbar expansion for settings

### DIFF
--- a/app/static/theme/theme.css
+++ b/app/static/theme/theme.css
@@ -80,6 +80,19 @@ body {
 .navbar-burger:hover { background: rgba(2, 6, 23, 0.06); }
 .navbar-burger.is-active { background: rgba(2, 6, 23, 0.08); }
 
+/* Navbar submenu: expands the navbar frame vertically (not a detached dropdown) */
+.navbar-submenu {
+    overflow: hidden;
+    max-height: 0;
+    transition: max-height 220ms ease;
+    border-top: 1px solid var(--color-border);
+}
+.navbar-submenu .tabs { margin-bottom: 0; }
+.navbar-submenu.is-open { max-height: 120px; }
+
+/* When settings is active/open, hide duplicate page-level tabs */
+body.has-subnav-open #settingsTabs { display: none; }
+
 /* Primary button remap to tokenized blue, with softer radius and shadow */
 .button.is-link {
     background-color: var(--color-primary);

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -47,6 +47,17 @@
                     </a>
                 </div>
             </div>
+            {% set settings_active_tab = request.query_params.get('tab') or 'proxy-list' %}
+            <div class="navbar-submenu {% if request.url.path == '/' %}is-open{% endif %}" id="settingsSubnav">
+                <div class="tabs is-small">
+                    <ul>
+                        <li class="{% if settings_active_tab == 'proxy-list' %}is-active{% endif %}"><a href="/?tab=proxy-list">프록시 목록</a></li>
+                        <li class="{% if settings_active_tab == 'proxy-groups' %}is-active{% endif %}"><a href="/?tab=proxy-groups">프록시 그룹</a></li>
+                        <li class="{% if settings_active_tab == 'resource-config' %}is-active{% endif %}"><a href="/?tab=resource-config">리소스 설정</a></li>
+                        <li class="{% if settings_active_tab == 'session-config' %}is-active{% endif %}"><a href="/?tab=session-config">세션브라우저 설정</a></li>
+                    </ul>
+                </div>
+            </div>
         </div>
     </nav>
 
@@ -83,6 +94,25 @@
                 const willOpen = !$acc.hasClass('is-open');
                 $acc.toggleClass('is-open', willOpen);
                 $body.stop(true, true).slideToggle(150);
+            });
+
+            // Settings submenu expand on hover/active
+            const isSettingsRoute = {% if request.url.path == '/' %}true{% else %}false{% endif %};
+            const $subnav = $('#settingsSubnav');
+            if (isSettingsRoute) {
+                $('body').addClass('has-subnav-open');
+                $subnav.addClass('is-open');
+            }
+            const $settingsItem = $('.navbar-end .navbar-item[href="/"]');
+            $settingsItem.on('mouseenter focusin', function(){
+                $('body').addClass('has-subnav-open');
+                $subnav.addClass('is-open');
+            });
+            $('.navbar').on('mouseleave', function(){
+                if (!isSettingsRoute) {
+                    $('body').removeClass('has-subnav-open');
+                    $subnav.removeClass('is-open');
+                }
             });
         });
     </script>

--- a/app/templates/components/settings.html
+++ b/app/templates/components/settings.html
@@ -1,17 +1,19 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="tabs">
+{% set active_tab = request.query_params.get('tab') or 'proxy-list' %}
+<div class="tabs" id="settingsTabs">
     <ul>
-        <li class="is-active" data-target="proxy-list"><a>프록시 목록</a></li>
-        <li data-target="proxy-groups"><a>프록시 그룹</a></li>
-        <li data-target="resource-config"><a>리소스 설정</a></li>
-        <li data-target="session-config"><a>세션브라우저 설정</a></li>
+        <li class="{% if active_tab == 'proxy-list' %}is-active{% endif %}" data-target="proxy-list"><a href="/?tab=proxy-list">프록시 목록</a></li>
+        <li class="{% if active_tab == 'proxy-groups' %}is-active{% endif %}" data-target="proxy-groups"><a href="/?tab=proxy-groups">프록시 그룹</a></li>
+        <li class="{% if active_tab == 'resource-config' %}is-active{% endif %}" data-target="resource-config"><a href="/?tab=resource-config">리소스 설정</a></li>
+        <li class="{% if active_tab == 'session-config' %}is-active{% endif %}" data-target="session-config"><a href="/?tab=session-config">세션브라우저 설정</a></li>
     </ul>
+
 </div>
 
 <!-- 프록시 목록 탭 -->
-<div id="proxy-list" class="tab-panel is-active">
+<div id="proxy-list" class="tab-panel {% if active_tab == 'proxy-list' %}is-active{% endif %}" style="{% if active_tab != 'proxy-list' %}display: none;{% endif %}">
     <div class="box">
         <div class="level">
             <div class="level-left">
@@ -47,7 +49,7 @@
 </div>
 
 <!-- 리소스 설정 탭 -->
-<div id="resource-config" class="tab-panel" style="display: none;">
+<div id="resource-config" class="tab-panel {% if active_tab == 'resource-config' %}is-active{% endif %}" style="{% if active_tab != 'resource-config' %}display: none;{% endif %}">
     <div class="box">
         <h3 class="title is-4">리소스 수집 설정</h3>
 
@@ -136,7 +138,7 @@
     </div>
 </div>
 <!-- 세션브라우저 설정 탭 -->
-<div id="session-config" class="tab-panel" style="display: none;">
+<div id="session-config" class="tab-panel {% if active_tab == 'session-config' %}is-active{% endif %}" style="{% if active_tab != 'session-config' %}display: none;{% endif %}">
     <div class="box">
         <div class="level">
             <div class="level-left">
@@ -193,7 +195,7 @@
     </div>
 </div>
 <!-- 프록시 그룹 탭 -->
-<div id="proxy-groups" class="tab-panel" style="display: none;">
+<div id="proxy-groups" class="tab-panel {% if active_tab == 'proxy-groups' %}is-active{% endif %}" style="{% if active_tab != 'proxy-groups' %}display: none;{% endif %}">
     <div class="box">
         <div class="level">
             <div class="level-left">
@@ -334,17 +336,19 @@ const utils = {
     resetForm: (formId) => document.getElementById(formId).reset()
 };
 
-// 탭 관리
-document.querySelectorAll('.tabs li').forEach(tab => {
-    tab.addEventListener('click', () => {
-        document.querySelectorAll('.tabs li').forEach(t => t.classList.remove('is-active'));
-        tab.classList.add('is-active');
-        
-        const target = tab.dataset.target;
-        document.querySelectorAll('.tab-panel').forEach(panel => {
-            panel.style.display = 'none';
-        });
-        document.getElementById(target).style.display = 'block';
+// 탭 관리: 링크를 통해 쿼리파람으로 동기화
+document.querySelectorAll('#settingsTabs li > a').forEach(function(a){
+    a.addEventListener('click', function(e){
+        const href = this.getAttribute('href') || '';
+        if (href.indexOf('/?tab=') === 0) { return; }
+        e.preventDefault();
+        const li = this.closest('li');
+        if (!li) return;
+        const target = li.getAttribute('data-target');
+        if (!target) return;
+        const url = new URL(window.location.href);
+        url.searchParams.set('tab', target);
+        window.location.href = url.toString();
     });
 });
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Integrate settings tabs into an expanding navbar submenu to improve navigation cohesion and user experience.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The existing floating navbar and separate settings tabs were not harmonized. This change consolidates the settings navigation by making the navbar itself expand vertically on hover/active, displaying the settings sub-menus directly within it. This provides a smoother, more integrated navigation flow and eliminates duplicate page-level tabs when the subnav is active.

---
<a href="https://cursor.com/background-agent?bcId=bc-579e4053-bc27-40a1-acff-bfdde0cafdd4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-579e4053-bc27-40a1-acff-bfdde0cafdd4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

