### PR TITLE
Fix nav bar sub menu display bug

### DIFF
--- a/app/static/theme/theme.css
+++ b/app/static/theme/theme.css
@@ -216,6 +216,9 @@ body {
     .navbar-menu .navbar-item.is-active {
         background: color-mix(in srgb, var(--color-primary) 10%, transparent) !important;
     }
+
+    /* Hide settings submenu entirely on mobile to avoid lingering below burger menu */
+    .navbar-submenu { display: none !important; }
 }
 
 /* Primary button remap to tokenized blue, with softer radius and shadow */

--- a/app/static/theme/theme.css
+++ b/app/static/theme/theme.css
@@ -106,6 +106,7 @@ body {
     transition: transform 220ms ease-in-out;
     width: 100%;
     flex: 0 0 100%;
+    overflow: hidden; /* ensure no content bleeds when collapsed */
 }
 
 /* Use a fixed collapsed height and auto-expand via JS class */
@@ -217,8 +218,16 @@ body {
         background: color-mix(in srgb, var(--color-primary) 10%, transparent) !important;
     }
 
-    /* Hide settings submenu entirely on mobile to avoid lingering below burger menu */
-    .navbar-submenu { display: none !important; }
+    /* Hide and fully collapse settings submenu on mobile */
+    .navbar-submenu {
+        display: none !important;
+        max-height: 0 !important;
+        padding: 0 !important;
+        margin: 0 !important;
+        border: 0 !important;
+        overflow: hidden !important;
+        transform: none !important;
+    }
 }
 
 /* Primary button remap to tokenized blue, with softer radius and shadow */

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -69,25 +69,43 @@
         $(document).ready(function() {
             // Navbar burger toggle
             $(document).on('click', '.navbar-burger', function() {
-                const targetId = $(this).attr('data-target');
-                $(this).toggleClass('is-active');
-                $('#' + targetId).toggleClass('is-active');
+                const $this = $(this);
+                const targetId = $this.attr('data-target');
+                const willBeActive = !$this.hasClass('is-active');
+                $this.toggleClass('is-active', willBeActive).attr('aria-expanded', willBeActive);
+                $('#' + targetId).toggleClass('is-active', willBeActive);
+                // Always collapse settings submenu when using burger
+                setNavbarExpanded(false);
             });
             // Navbar expandable (hover-only for settings)
             const $navbar = $('.navbar');
+            const desktopQuery = window.matchMedia('(min-width: 1024px)');
             let collapseTimer = null;
             function setNavbarExpanded(expanded) {
                 $navbar.toggleClass('is-expanded', !!expanded);
             }
             // start collapsed
             setNavbarExpanded(false);
+            function updateNavbarMode() {
+                if (!desktopQuery.matches) {
+                    setNavbarExpanded(false);
+                }
+            }
+            if (typeof desktopQuery.addEventListener === 'function') {
+                desktopQuery.addEventListener('change', updateNavbarMode);
+            } else if (typeof desktopQuery.addListener === 'function') {
+                desktopQuery.addListener(updateNavbarMode);
+            }
+            updateNavbarMode();
             // open on hover over settings item or submenu
             $(document).on('mouseenter', '#navSettings, .navbar-submenu', function() {
+                if (!desktopQuery.matches) return;
                 if (collapseTimer) { clearTimeout(collapseTimer); collapseTimer = null; }
                 setNavbarExpanded(true);
             });
             // close with a small delay when leaving entire navbar area
             $(document).on('mouseleave', '.navbar', function(e) {
+                if (!desktopQuery.matches) return;
                 const self = this;
                 const related = e.relatedTarget;
                 if (related && $.contains(self, related)) return;


### PR DESCRIPTION
Fix a bug where the settings submenu would linger below the burger menu on mobile by hiding it and ensuring it collapses with the burger menu.

---
<a href="https://cursor.com/background-agent?bcId=bc-395cccba-5361-4488-a4fb-b2f38bec5094">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-395cccba-5361-4488-a4fb-b2f38bec5094">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

